### PR TITLE
Present custom edit menu on long press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file. Take a look
 
 **Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with caution.
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+#### Shared
+
+* The `Link` property key for archive-based publication assets (e.g. an EPUB/ZIP) is now `https://readium.org/webpub-manifest/properties#archive` instead of `archive`.
+
 
 ## [3.0.0-alpha.1]
 

--- a/Sources/Shared/Fetcher/ArchiveFetcher.swift
+++ b/Sources/Shared/Fetcher/ArchiveFetcher.swift
@@ -90,10 +90,7 @@ public final class ArchiveFetcher: Fetcher, Loggable {
 private extension ArchiveEntry {
     var linkProperties: [String: Any] {
         [
-            // FIXME: Legacy property, should be removed in 3.0.0
-            "compressedLength": compressedLength as Any,
-
-            "archive": [
+            "https://readium.org/webpub-manifest/properties#archive": [
                 "entryLength": compressedLength ?? length,
                 "isEntryCompressed": compressedLength != nil,
             ] as [String: Any],

--- a/Sources/Shared/Publication/Extensions/Archive/Properties+Archive.swift
+++ b/Sources/Shared/Publication/Extensions/Archive/Properties+Archive.swift
@@ -50,6 +50,6 @@ public extension Properties {
 
     /// Provides information about how the resource is stored in the publication archive.
     var archive: Archive? {
-        try? Archive(json: otherProperties["archive"], warnings: self)
+        try? Archive(json: otherProperties["https://readium.org/webpub-manifest/properties#archive"], warnings: self)
     }
 }

--- a/TestApp/Sources/App/AppModule.swift
+++ b/TestApp/Sources/App/AppModule.swift
@@ -20,6 +20,7 @@ protocol ModuleDelegate: AnyObject {
 /// Main application module, it:
 /// - owns the sub-modules (library, reader, etc.)
 /// - orchestrates the communication between its sub-modules, through the modules' delegates.
+@available(iOS 16.0, *)
 final class AppModule {
     // App modules
     var library: LibraryModuleAPI!
@@ -52,6 +53,7 @@ final class AppModule {
     }()
 }
 
+@available(iOS 16.0, *)
 extension AppModule: ModuleDelegate {
     func presentAlert(_ title: String, message: String, from viewController: UIViewController) {
         DispatchQueue.main.async {
@@ -76,14 +78,17 @@ extension AppModule: ModuleDelegate {
     }
 }
 
+@available(iOS 16.0, *)
 extension AppModule: LibraryModuleDelegate {
     func libraryDidSelectPublication(_ publication: Publication, book: Book) {
         reader.presentPublication(publication: publication, book: book, in: library.rootViewController)
     }
 }
 
+@available(iOS 16.0, *)
 extension AppModule: ReaderModuleDelegate {}
 
+@available(iOS 16.0, *)
 extension AppModule: OPDSModuleDelegate {
     func opdsDownloadPublication(_ publication: Publication?, at link: Link, sender: UIViewController) async throws -> Book {
         let url = try link.url(relativeTo: publication?.baseURL)

--- a/TestApp/Sources/AppDelegate.swift
+++ b/TestApp/Sources/AppDelegate.swift
@@ -7,6 +7,7 @@
 import Combine
 import UIKit
 
+@available(iOS 16.0, *)
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?

--- a/TestApp/Sources/Reader/PDF/PDFModule.swift
+++ b/TestApp/Sources/Reader/PDF/PDFModule.swift
@@ -9,6 +9,7 @@ import ReadiumNavigator
 import ReadiumShared
 import UIKit
 
+@available(iOS 16.0, *)
 final class PDFModule: ReaderFormatModule {
     weak var delegate: ReaderFormatModuleDelegate?
 

--- a/TestApp/Sources/Reader/ReaderModule.swift
+++ b/TestApp/Sources/Reader/ReaderModule.swift
@@ -21,6 +21,7 @@ protocol ReaderModuleAPI {
 
 protocol ReaderModuleDelegate: ModuleDelegate {}
 
+@available(iOS 16.0, *)
 final class ReaderModule: ReaderModuleAPI {
     weak var delegate: ReaderModuleDelegate?
     private let books: BookRepository
@@ -75,6 +76,7 @@ final class ReaderModule: ReaderModuleAPI {
     }
 }
 
+@available(iOS 16.0, *)
 extension ReaderModule: ReaderFormatModuleDelegate {
     func presentDRM(for publication: Publication, from viewController: UIViewController) {
         let drmViewController: DRMManagementTableViewController = factory.make(publication: publication, delegate: delegate)

--- a/Tests/SharedTests/Fetcher/ArchiveFetcherTests.swift
+++ b/Tests/SharedTests/Fetcher/ArchiveFetcherTests.swift
@@ -32,8 +32,7 @@ class ArchiveFetcherTests: XCTestCase {
                 ("META-INF/container.xml", "application/xml", 176, true),
             ].map { href, type, entryLength, isCompressed in
                 Link(href: href, type: type, properties: .init([
-                    "compressedLength": (isCompressed ? entryLength : nil) as Any, // legacy
-                    "archive": [
+                    "https://readium.org/webpub-manifest/properties#archive": [
                         "entryLength": entryLength,
                         "isEntryCompressed": isCompressed,
                     ] as [String: Any],
@@ -89,11 +88,10 @@ class ArchiveFetcherTests: XCTestCase {
         AssertJSONEqual(
             resource.link.properties.json,
             [
-                "archive": [
+                "https://readium.org/webpub-manifest/properties#archive": [
                     "entryLength": 595,
                     "isEntryCompressed": true,
                 ] as [String: Any],
-                "compressedLength": 595,
             ] as [String: Any]
         )
     }

--- a/Tests/SharedTests/Publication/Extensions/Archive/Properties+ArchiveTests.swift
+++ b/Tests/SharedTests/Publication/Extensions/Archive/Properties+ArchiveTests.swift
@@ -14,7 +14,7 @@ class PropertiesArchiveTests: XCTestCase {
     }
 
     func testArchive() {
-        let sut = Properties(["archive": [
+        let sut = Properties(["https://readium.org/webpub-manifest/properties#archive": [
             "entryLength": 8273,
             "isEntryCompressed": true,
         ] as [String: Any]])
@@ -23,19 +23,19 @@ class PropertiesArchiveTests: XCTestCase {
     }
 
     func testInvalidArchive() {
-        let sut = Properties(["archive": [
+        let sut = Properties(["https://readium.org/webpub-manifest/properties#archive": [
             "foo": "bar",
         ]])
         XCTAssertNil(sut.archive)
     }
 
     func testIncompleteArchive() {
-        var sut = Properties(["archive": [
+        var sut = Properties(["https://readium.org/webpub-manifest/properties#archive": [
             "entryLength": 8273,
         ]])
         XCTAssertNil(sut.archive)
 
-        sut = Properties(["archive": [
+        sut = Properties(["https://readium.org/webpub-manifest/properties#archive": [
             "isEntryCompressed": true,
         ]])
         XCTAssertNil(sut.archive)

--- a/Tests/StreamerTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
+++ b/Tests/StreamerTests/Parser/EPUB/Services/EPUBPositionsServiceTests.swift
@@ -440,7 +440,7 @@ private func makeProperties(layout: EPUBLayout? = nil, archiveEntryLength: UInt6
         ] as [String: Any]
     }
     if let archiveEntryLength = archiveEntryLength {
-        props["archive"] = [
+        props["https://readium.org/webpub-manifest/properties#archive"] = [
             "entryLength": archiveEntryLength as NSNumber,
             "isEntryCompressed": true,
         ]


### PR DESCRIPTION
https://github.com/goatboyzz/swift-toolkit/assets/15877903/fa6262d3-0fd7-43d4-a800-f63cf89e913d

Was not able to customize the edit menu for text edit but was able to customize the edit menu for long press.

To reproduce, you can highlight a text and long press on it 

Reference: https://stackoverflow.com/questions/73712955/using-uieditmenuinteraction-with-uitextview